### PR TITLE
Bug/Pin aws s3 module version to current latest v2.9.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,7 @@ module "config_label" {
 ## Config bucket
 module "config_bucket" {
   source                  = "terraform-aws-modules/s3-bucket/aws"
+  version                 = "v2.9.0"
   bucket                  = module.config_label.id
   acl                     = "private"
   block_public_acls       = true
@@ -121,7 +122,7 @@ module "config" {
   source             = "trussworks/config/aws"
   version            = "4.3.0"
   config_name        = module.config_label.id
-  config_logs_bucket = module.config_bucket.this_s3_bucket_id
+  config_logs_bucket = module.config_bucket.s3_bucket_id
   #config_sns_topic_arn                     = aws_sns_topic.config.arn
   check_cloud_trail_encryption             = true
   check_cloud_trail_log_file_validation    = true

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
 output "config_bucket_name" {
-  value = module.config_bucket.this_s3_bucket_id
+  value = module.config_bucket.s3_bucket_id
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

AWS s3 module is used on **tf-aws-config** module with no pinned version, so every time the module is used, it is downloaded the latest s3 module version.

4 months ago it was generated `v2.9.0` which updated all the output names on commit https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/commit/161026d6e56fbe9695a1060ad33607b819cf784a, updating all outputs from  `this_s3_bucket_id` to  `s3_bucket_id`, removing prefix `this_`.

This makes current **tf-aws-config** module to break, because this module depends on deprecated s3-module output names which are not present anymore:

```bash
$ terraform plan
Acquiring state lock. This may take a few moments...
Releasing state lock. This may take a few moments...
╷
│ Error: Unsupported attribute
│ 
│   on .terraform/modules/config/main.tf line 124, in module "config":
│  124:   config_logs_bucket = module.config_bucket.this_s3_bucket_id
│     ├────────────────
│     │ module.config_bucket is a object, known only after apply
│ 
│ This object does not have an attribute named "this_s3_bucket_id".
╵
╷
│ Error: Unsupported attribute
│ 
│   on .terraform/modules/config/outputs.tf line 2, in output "config_bucket_name":
│    2:   value = module.config_bucket.this_s3_bucket_id
│     ├────────────────
│     │ module.config_bucket is a object, known only after apply
│ 
```

So this PR pins the s3 module to the current latest version `v2.9.0`, and adapts the s3 output names to this version, so from now on anyone using **tf-aws-config** module will work without introducing possible breakign changes.


#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., usage docs, etc.:

N/A

/priority important-soon
/assign