### PR TITLE
clean: rename link to the 3scale-sre github org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 # tf-aws-config
 
-[![format-tests](https://github.com/3scale-ops/tf-aws-config/workflows/format-tests/badge.svg)](https://github.com/3scale-ops/tf-aws-config/actions/workflows/format-tests.yaml?query=workflow%3Aformat-tests)
-[![license](https://badgen.net/github/license/3scale-ops/tf-aws-config)](https://github.com/3scale-ops/tf-aws-config/blob/main/LICENSE)
+[![format-tests](https://github.com/3scale-sre/tf-aws-config/workflows/format-tests/badge.svg)](https://github.com/3scale-sre/tf-aws-config/actions/workflows/format-tests.yaml?query=workflow%3Aformat-tests)
+[![license](https://badgen.net/github/license/3scale-sre/tf-aws-config)](https://github.com/3scale-sre/tf-aws-config/blob/main/LICENSE)
 
 This module tries to standarize the way we configure AWS Config in aws accounts
 
 ## Outputs
 
-| Output | Description                               |
-| ------ | ----------------------------------------- |
+| Output             | Description           |
+| ------------------ | --------------------- |
 | config_bucket_name | Config S3 bucket name |
 
 ## Contributing
 
 You can contribute by:
 
-* Raising any issues you find using the module
-* Fixing issues by opening [Pull Requests](https://github.com/3scale-ops/tf-aws-config/pulls)
-* Submitting a patch or opening a PR
-* Improving documentation
-* Talking about the module
+- Raising any issues you find using the module
+- Fixing issues by opening [Pull Requests](https://github.com/3scale-sre/tf-aws-config/pulls)
+- Submitting a patch or opening a PR
+- Improving documentation
+- Talking about the module
 
-All bugs, tasks or enhancements are tracked as [GitHub issues](https://github.com/3scale-ops/tf-aws-config/issues).
+All bugs, tasks or enhancements are tracked as [GitHub issues](https://github.com/3scale-sre/tf-aws-config/issues).

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 ## Label
 module "config_label" {
-  source      = "git@github.com:3scale-ops/tf-aws-label.git?ref=tags/0.1.2"
+  source      = "git@github.com:3scale-sre/tf-aws-label.git?ref=tags/0.1.2"
   project     = var.project
   environment = var.environment
   workload    = var.workload


### PR DESCRIPTION
### What type of PR is this?
/kind cleanup
/kind documentation

### What this PR does / why we need it:
Updates all links to point to the 3scale-sre org after the migration.

### Notes
/kind cleanup
/kind documentation
/assign
/priority important-longterm